### PR TITLE
Increment reference count of Pollpri to prevent garbage collection

### DIFF
--- a/node_modules/bonescript/misc.cpp
+++ b/node_modules/bonescript/misc.cpp
@@ -91,6 +91,9 @@ public:
         p->path = (char *)malloc(path.length() + 1);
         strncpy(p->path, *path, path.length() + 1);
         
+        // Increment reference count to prevent garbage collection
+        p->Ref();
+        
         // Open file to watch
         int fd = open(p->path, O_RDWR | O_NONBLOCK);
         PRINTF("open(%s) returned %d: %s\n", p->path, fd, strerror(errno));


### PR DESCRIPTION
Hi Jason,

this is a small fix for preventing garbage collection of the Pollpri node extension.
It seems that the fork in attachInterrupt with gpioint.js is a workaround because the object got garbage collected, or am I wrong? If not it could be cleared up I think.

Best regards from Hamburg

Max
