### PR TITLE
variable "n" is needed before it was actually created. bug fixed.

### DIFF
--- a/node_modules/bonescript/index.js
+++ b/node_modules/bonescript/index.js
@@ -118,6 +118,7 @@ f.pinMode = function(pin, direction, mux, pullup, slew, callback) {
 
     var muxFile = '/sys/kernel/debug/omap_mux/' + pin.mux;
     var gpioFile = '/sys/class/gpio/gpio' + pin.gpio + '/value';
+    var n = pin.gpio;
     
     // Handle case where pin is allocated as a gpio-led
     if(pin.led) {
@@ -183,7 +184,6 @@ f.pinMode = function(pin, direction, mux, pullup, slew, callback) {
     }
     
     // Enable GPIO, if not already done
-    var n = pin.gpio;
     if(mux == 7) {
         if(!gpio[n] || !gpio[n].path) {
             gpio[n] = {'path': gpioFile};


### PR DESCRIPTION
variable "n" was needed by code before it had actually been created.  this pull fixes that bug.
