### PR TITLE
Fixed logical error for callback of file_exists.

### DIFF
--- a/src/my.js
+++ b/src/my.js
@@ -200,7 +200,7 @@ exports.create_dt = function(pin, data, template, load, force_create, resp, call
     if(force_create) {
         createDTS();
     } else {
-        exports.file_exists(dtboFilename, onDTBOExists);
+        exports.file_exists(dtboFilename, onDTBOExistsTest);
     }
     
     function onDTBOExistsTest(exists) {


### PR DESCRIPTION
 `exports.file_exists` should callback `onDTBOExistsTest` and check if the device tree can be loaded readily or needs to be compiled.
