### PR TITLE
Fix misprint in hw_oldkernel.js

### DIFF
--- a/src/hw_oldkernel.js
+++ b/src/hw_oldkernel.js
@@ -64,6 +64,7 @@ exports.setPinMode = function(pin, pinData, template, resp) {
         fs.writeSync(fd, pinData.toString(16), null);
     } catch(ex) {
         resp.err = 'Error writing to ' + muxFile + ': ' + ex;
+        return(resp);
     }
 
     if(template == 'bspm') {
@@ -84,6 +85,7 @@ exports.setPinMode = function(pin, pinData, template, resp) {
         fs.writeFileSync(path+'/polarity', '0');
         fs.writeFileSync(path+'/run', '1');
     }
+    return(resp);
 };
 
 exports.setLEDPinToGPIO = function(pin, resp) {


### PR DESCRIPTION
Looks like return statement was omitted from setPinMode,

Before change I've seen errors like this:
Can not switch pin P9_12 into OUTPUT mode: TypeError: Cannot read property 'err' of undefined
    at Object.f.pinMode (/home/ubuntu/node-nest/node_modules/bonescript/index.js:161:19)
    at ...
    at /home/ubuntu/node-nest/node_modules/unofficial-nest-api/index.js:231:17
    at IncomingMessage.<anonymous> (/home/ubuntu/node-nest/node_modules/unofficial-nest-api/index.js:213:25)
    at IncomingMessage.EventEmitter.emit (events.js:117:20)