### PR TITLE
Update node to >= 0.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "main": "main",
   "engines": {
-    "node": ">= 0.10.1"
+    "node": ">= 0.12.1"
   },
   "dependencies": {
     "socket.io": "1.4.5",


### PR DESCRIPTION
Currently node v0.12.x is the default for Debian 8.4.  Also the optional dependancy i2c v0.2.1 conflicts with node v0.10.x.