### PR TITLE
nodejs v4.x: switch optional dep spi to pi-spi

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "serialport": "2.0.6",
     "i2c": "0.2.1",
     "epoll": "0.1.17",
-    "spi": "0.2.0"
+    "pi-spi": "1.0.1"
   },
   "devDependencies": {
     "jscoverage": "~0.5.1",


### PR DESCRIPTION
Based on https://github.com/natevw/pi-spi/issues/17 node-spi probally will never supplry nodejs > v0.12.x

(i2c still requires nodejs v0.12.x)

Signed-off-by: Robert Nelson <robertcnelson@gmail.com>