### PR TITLE
Fixed path for 4.4 kernel

### DIFF
--- a/src/hw_mainline.js
+++ b/src/hw_mainline.js
@@ -92,7 +92,7 @@ exports.setPinMode = function(pin, pinData, template, resp, callback) {
         // file_find figures which pwmchip to use
         // pin.pwm.index tells with half of the PWM to use (0 or 1)
         var pwmPath = my.file_find('/sys/devices/platform/ocp/'+pin.pwm.chip
-                + '.epwmss/'+pin.pwm.addr+'.ehrpwm/pwm', 'pwmchip', 1);
+                + '.epwmss/'+pin.pwm.addr+'.pwm/pwm', 'pwmchip', 1);
         pwmPrefix[pin.pwm.name] = pwmPath + '/pwm' + pin.pwm.index;
         if(debug) winston.debug("pwmPrefix[pin.pwm.name] = " + pwmPrefix[pin.pwm.name]);
         if(debug) winston.debug("pin.pwm.sysfs = " + pin.pwm.sysfs);


### PR DESCRIPTION
Mark Yoder -
Hmmmm.. the pwm path appears to have changed for the 4.4 kernel.  Bonescript uses

/sys/devices/platform/ocp/48304000.epwmss/48304200.ehrpwm/pwm/pwmchip6, but the new 4.4 kernel path is

/sys/devices/platform/ocp/48304000.epwmss/48304200.pwm/pwm/pwmchip6  (the ehr is missing).

This got changed in:

https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/arch/arm/boot/dts/am33xx.dtsi?id=dce2a6524963f58e7fd0b8888b2d3791c150f42c

and then backported to ti's v4.4.x branch..