### PR TITLE
PWM improvements

### DIFF
--- a/src/bone.js
+++ b/src/bone.js
@@ -279,6 +279,8 @@ var pinIndex = [
         "gpio": 23,
         "mux": "gpmc_ad9",
         "eeprom": 15,
+        // From am335x technical manual, p.183
+        // http://www.ti.com/lit/ug/spruh73n/spruh73n.pdf
         "pwm": {
             "module": "ehrpwm2",
             "sysfs": 6,
@@ -397,6 +399,8 @@ var pinIndex = [
         "gpio": 22,
         "mux": "gpmc_ad8",
         "eeprom": 14,
+        // From am335x technical manual, p.183
+        // http://www.ti.com/lit/ug/spruh73n/spruh73n.pdf
         "pwm": {
             "module": "ehrpwm2",
             "sysfs": 5,
@@ -677,6 +681,8 @@ var pinIndex = [
         "gpio": 81,
         "mux": "lcd_data11",
         "eeprom": 56,
+        // From am335x technical manual, p.183
+        // http://www.ti.com/lit/ug/spruh73n/spruh73n.pdf
         "pwm": {
             "module": "ehrpwm1",
             "sysfs": 4,
@@ -723,6 +729,8 @@ var pinIndex = [
         "gpio": 80,
         "mux": "lcd_data10",
         "eeprom": 55,
+        // From am335x technical manual, p.183
+        // http://www.ti.com/lit/ug/spruh73n/spruh73n.pdf
         "pwm": {
             "module": "ehrpwm1",
             "sysfs": 3,
@@ -895,6 +903,8 @@ var pinIndex = [
         "gpio": 70,
         "mux": "lcd_data0",
         "eeprom": 45,
+        // From am335x technical manual, p.183
+        // http://www.ti.com/lit/ug/spruh73n/spruh73n.pdf
         "pwm": {
             "module": "ehrpwm2",
             "sysfs": 5,
@@ -923,6 +933,8 @@ var pinIndex = [
         "gpio": 71,
         "mux": "lcd_data1",
         "eeprom": 46,
+        // From am335x technical manual, p.183
+        // http://www.ti.com/lit/ug/spruh73n/spruh73n.pdf
         "pwm": {
             "module": "ehrpwm2",
             "sysfs": 6,
@@ -1045,6 +1057,8 @@ var pinIndex = [
         "gpio": 50,
         "mux": "gpmc_a2",
         "eeprom": 34,
+        // From am335x technical manual, p.183
+        // http://www.ti.com/lit/ug/spruh73n/spruh73n.pdf
         "pwm": {
             "module": "ehrpwm1",
             "sysfs": 3,
@@ -1091,6 +1105,8 @@ var pinIndex = [
         "gpio": 51,
         "mux": "gpmc_a3",
         "eeprom": 35,
+        // From am335x technical manual, p.183
+        // http://www.ti.com/lit/ug/spruh73n/spruh73n.pdf
         "pwm": {
             "module": "ehrpwm1",
             "sysfs": 4,
@@ -1191,6 +1207,8 @@ var pinIndex = [
         "gpio": 3,
         "mux": "spi0_d0",
         "eeprom": 1,
+        // From am335x technical manual, p.183
+        // http://www.ti.com/lit/ug/spruh73n/spruh73n.pdf
         "pwm": {
             "module": "ehrpwm0",
             "sysfs": 1,
@@ -1219,6 +1237,8 @@ var pinIndex = [
         "gpio": 2,
         "mux": "spi0_sclk",
         "eeprom": 0,
+        // From am335x technical manual, p.183
+        // http://www.ti.com/lit/ug/spruh73n/spruh73n.pdf
         "pwm": {
             "module": "ehrpwm0",
             "sysfs": 0,
@@ -1337,13 +1357,18 @@ var pinIndex = [
         "gpio": 113,
         "mux": "mcasp0_ahclkr",
         "eeprom": 63,
+        // From am335x technical manual, p.183
+        // http://www.ti.com/lit/ug/spruh73n/spruh73n.pdf
         "pwm": {
             "module": "ecap2",
             "sysfs": 7,
             "index": 2,
             "muxmode": 4,
             "path": "ecap.2",
-            "name": "ECAPPWM2"
+            "name": "ECAPPWM2",
+
+            "chip": "48304000",
+            "addr": "48304100"
         },
         "key": "P9_28",
         "muxRegOffset": "0x19c",
@@ -1363,6 +1388,8 @@ var pinIndex = [
         "gpio": 111,
         "mux": "mcasp0_fsx",
         "eeprom": 61,
+        // From am335x technical manual, p.183
+        // http://www.ti.com/lit/ug/spruh73n/spruh73n.pdf
         "pwm": {
             "module": "ehrpwm0",
             "sysfs": 1,
@@ -1409,6 +1436,8 @@ var pinIndex = [
         "gpio": 110,
         "mux": "mcasp0_aclkx",
         "eeprom": 65,
+        // From am335x technical manual, p.183
+        // http://www.ti.com/lit/ug/spruh73n/spruh73n.pdf
         "pwm": {
             "module": "ehrpwm0",
             "sysfs": 0,
@@ -1512,6 +1541,8 @@ var pinIndex = [
         "gpio": 7,
         "mux": "ecap0_in_pwm0_out",
         "eeprom": 4,
+        // From am335x technical manual, p.183
+        // http://www.ti.com/lit/ug/spruh73n/spruh73n.pdf
         "pwm": {
             "module": "ecap0",
             "sysfs": 2,
@@ -1519,6 +1550,8 @@ var pinIndex = [
             "muxmode": 0,
             "path": "ecap.0",
             "name": "ECAPPWM0"
+            "chip": "48300000",
+            "addr": "48300100"
         },
         "key": "P9_42",
         "muxRegOffset": "0x164",

--- a/src/bone.js
+++ b/src/bone.js
@@ -1549,7 +1549,7 @@ var pinIndex = [
             "index": 0,
             "muxmode": 0,
             "path": "ecap.0",
-            "name": "ECAPPWM0"
+            "name": "ECAPPWM0",
             "chip": "48300000",
             "addr": "48300100"
         },

--- a/src/hw_mainline.js
+++ b/src/hw_mainline.js
@@ -93,6 +93,12 @@ exports.setPinMode = function(pin, pinData, template, resp, callback) {
         // pin.pwm.index tells with half of the PWM to use (0 or 1)
         var pwmPath = my.file_find('/sys/devices/platform/ocp/'+pin.pwm.chip
                 + '.epwmss/'+pin.pwm.addr+'.pwm/pwm', 'pwmchip', 1);
+        // Some versions of kernel (4.4.15-bone11 for instance) still use
+        // .ehrpwm for address
+        if (pwmPath == null) {
+        	pwmPath = my.file_find('/sys/devices/platform/ocp/'+pin.pwm.chip
+        		+ '.epwmss/'+pin.pwm.addr+'.ehrpwm/pwm', 'pwmchip', 1)
+        }
         pwmPrefix[pin.pwm.name] = pwmPath + '/pwm' + pin.pwm.index;
         if(debug) winston.debug("pwmPrefix[pin.pwm.name] = " + pwmPrefix[pin.pwm.name]);
         if(debug) winston.debug("pin.pwm.sysfs = " + pin.pwm.sysfs);


### PR DESCRIPTION
From the TI reference manual, added addresses for the eCap PWM components.

From experience with the 4.4.15-bone11 kernel, added a way to handle devices which still use the old filesystem path for the ehrpwm.