### PR TITLE
Fixed PWM for ECAP (P9_28 and P9_42)

### DIFF
--- a/src/bone.js
+++ b/src/bone.js
@@ -1362,7 +1362,7 @@ var pinIndex = [
         "pwm": {
             "module": "ecap2",
             "sysfs": 7,
-            "index": 2,
+            "index": 0,
             "muxmode": 4,
             "path": "ecap.2",
             "name": "ECAPPWM2",


### PR DESCRIPTION
Hi,

Latest master is not working with kernel 4.4.\* when pins P9_28 and P9_42 are used so I created fix for that. P9_28 wants that pin mode is pwm2 instead of pwm and in bone.js P9_28 index was 2 when correct index is 0 as ecaps are having only 1 outputs both. I used several days to get all 8 pwm channels working at the same time so if somebody is trying to achieve same, I am happy to help!

Br,
Janne
