### PR TITLE
Updated for Blue GPIO pins

### DIFF
--- a/src/bone.js
+++ b/src/bone.js
@@ -79,45 +79,6 @@ var pinIndex = [
             "gpio1_24"
         ]
     },
-    
-    // Added for Blue
-    {
-        "name": "RED_LED",
-        "gpio": 66,
-        "led": "red",
-        "mux": "gpmc_a8",
-        "key": "RED_LED",
-        "muxRegOffset": "0x060",
-        "options": [
-            "gpmc_a8",
-            "gmii2_rxd3",
-            "rgmii2_rd3",
-            "mmc2_dat6",
-            "gpmc_a24",
-            "pr1_mii1_rxd0",
-            "mcasp0_aclkx",
-            "gpio1_24"
-        ]
-    },
-    {
-        "name": "GREEN_LED",
-        "gpio": 67,
-        "led": "green",
-        "mux": "gpmc_a8",
-        "key": "GREEN_LED",
-        "muxRegOffset": "0x060",
-        "options": [
-            "gpmc_a8",
-            "gmii2_rxd3",
-            "rgmii2_rd3",
-            "mmc2_dat6",
-            "gpmc_a24",
-            "pr1_mii1_rxd0",
-            "mcasp0_aclkx",
-            "gpio1_24"
-        ]
-    },
-    
     {
         "name": "DGND",
         "key": "P8_1"
@@ -221,6 +182,27 @@ var pinIndex = [
             "mmc1_sdcd"
         ]
     },
+    // Added for Blue
+    {
+        "name": "RED_LED",
+        "gpio": 66,
+        "led":  "red",
+        "mux": "gpmc_advn_ale",
+        "eeprom": 41,
+        "key": "RED_LED",
+        "universalName": "RED_LED",
+        "muxRegOffset": "0x090",
+        "options": [
+            "gpmc_advn_ale",
+            "NA",
+            "NA",
+            "NA",
+            "NA",
+            "NA",
+            "NA",
+            "mmc1_sdcd"
+        ]
+    },
     {
         "name": "TIMER7",
         "gpio": 67,
@@ -228,6 +210,28 @@ var pinIndex = [
         "eeprom": 44,
         "key": "P8_8",
         "universalName": "P8_08",
+        "muxRegOffset": "0x094",
+        "options": [
+            "gpmc_oen_ren",
+            "NA",
+            "NA",
+            "NA",
+            "NA",
+            "NA",
+            "NA",
+            "gpio2_3"
+        ]
+    },
+    
+    // Added for Blue
+    {
+        "name": "GREEN_LED",
+        "gpio": 67,
+        "led": "green",
+        "mux": "gpmc_oen_ren",
+        "eeprom": 44,
+        "key": "GREEN_LED",
+        "universalName": "GREEN_LED",
         "muxRegOffset": "0x094",
         "options": [
             "gpmc_oen_ren",
@@ -1307,6 +1311,7 @@ var pinIndex = [
         "mux": "gpmc_a1",
         "eeprom": 33,
         "key": "P9_23",
+        "key2": "GP0_4",        // Added for Blue
         "muxRegOffset": "0x044",
         "options": [
             "gpmc_a1",
@@ -1410,6 +1415,7 @@ var pinIndex = [
             "addr": "48304100"
         },
         "key": "P9_28",
+        "key2": "GP0_6",        // Added for Blue
         "muxRegOffset": "0x19c",
         "options": [
             "mcasp0_ahclkr",
@@ -1626,6 +1632,9 @@ var pinIndex = [
 var pins = {};
 for(var i in pinIndex) {
     pins[pinIndex[i].key] = pinIndex[i];
+    if(pinIndex[i].key2) {
+        pins[pinIndex[i].key2] = pinIndex[i];
+    }
 }
 
 var uarts = {

--- a/src/bone.js
+++ b/src/bone.js
@@ -1324,7 +1324,7 @@ var pinIndex = [
             "gpio1_17"
         ]
     },
-    {       // The next two are hacks to get the Blue GP0 pins 3 and 5 to work
+    {       // The next four are hacks to get the Blue GP0 pins 3 and 5 to work
         "name": "GPIO1_25",
         "gpio": 57,
         "mux": "gpmc_a1",
@@ -1360,6 +1360,44 @@ var pinIndex = [
             "pr1_mii1_txd3",
             "ehrpwm0_synco",
             "gpio3_20"
+        ]
+    },
+    {
+        "name": "GPIO3_2",
+        "gpio": 98,
+        "mux": "gpmc_a1",
+        "eeprom": 33,
+        "key": "XXX",
+        "key2": "GP1_3",        // Added for Blue
+        "muxRegOffset": "0x044",
+        "options": [
+            "gpmc_a1",
+            "gmii2_rxdv",
+            "rgmii2_rctl",
+            "mmc2_dat0",
+            "gpmc_a17",
+            "pr1_mii1_txd3",
+            "ehrpwm0_synco",
+            "gpio3_2"
+        ]
+    },
+    {
+        "name": "GPIO3_1",
+        "gpio": 97,
+        "mux": "gpmc_a1",
+        "eeprom": 33,
+        "key": "XXX",
+        "key2": "GP1_4",        // Added for Blue
+        "muxRegOffset": "0x044",
+        "options": [
+            "gpmc_a1",
+            "gmii2_rxdv",
+            "rgmii2_rctl",
+            "mmc2_dat0",
+            "gpmc_a17",
+            "pr1_mii1_txd3",
+            "ehrpwm0_synco",
+            "gpio3_1"
         ]
     },
 

--- a/src/bone.js
+++ b/src/bone.js
@@ -250,6 +250,7 @@ var pinIndex = [
         "mux": "gpmc_ben0_cle",
         "eeprom": 42,
         "key": "P8_9",
+        "key2": "PAUSE",
         "universalName": "P8_09",
         "muxRegOffset": "0x09c",
         "options": [
@@ -269,6 +270,7 @@ var pinIndex = [
         "mux": "gpmc_wen",
         "eeprom": 43,
         "key": "P8_10",
+        "key2": "MODE",
         "muxRegOffset": "0x098",
         "options": [
             "gpmc_wen",

--- a/src/bone.js
+++ b/src/bone.js
@@ -184,13 +184,13 @@ var pinIndex = [
     },
     // Added for Blue
     {
-        "name": "RED_LED",
+        "name": "RED",
         "gpio": 66,
         "led":  "red",
         "mux": "gpmc_advn_ale",
         "eeprom": 41,
-        "key": "RED_LED",
-        "universalName": "RED_LED",
+        "key": "RED",
+        "universalName": "RED",
         "muxRegOffset": "0x090",
         "options": [
             "gpmc_advn_ale",
@@ -225,13 +225,13 @@ var pinIndex = [
     
     // Added for Blue
     {
-        "name": "GREEN_LED",
+        "name": "GREEN",
         "gpio": 67,
         "led": "green",
         "mux": "gpmc_oen_ren",
         "eeprom": 44,
-        "key": "GREEN_LED",
-        "universalName": "GREEN_LED",
+        "key": "GREEN",
+        "universalName": "GREEN",
         "muxRegOffset": "0x094",
         "options": [
             "gpmc_oen_ren",

--- a/src/bone.js
+++ b/src/bone.js
@@ -79,6 +79,45 @@ var pinIndex = [
             "gpio1_24"
         ]
     },
+    
+    // Added for Blue
+    {
+        "name": "RED_LED",
+        "gpio": 66,
+        "led": "red",
+        "mux": "gpmc_a8",
+        "key": "RED_LED",
+        "muxRegOffset": "0x060",
+        "options": [
+            "gpmc_a8",
+            "gmii2_rxd3",
+            "rgmii2_rd3",
+            "mmc2_dat6",
+            "gpmc_a24",
+            "pr1_mii1_rxd0",
+            "mcasp0_aclkx",
+            "gpio1_24"
+        ]
+    },
+    {
+        "name": "GREEN_LED",
+        "gpio": 67,
+        "led": "green",
+        "mux": "gpmc_a8",
+        "key": "GREEN_LED",
+        "muxRegOffset": "0x060",
+        "options": [
+            "gpmc_a8",
+            "gmii2_rxd3",
+            "rgmii2_rd3",
+            "mmc2_dat6",
+            "gpmc_a24",
+            "pr1_mii1_rxd0",
+            "mcasp0_aclkx",
+            "gpio1_24"
+        ]
+    },
+    
     {
         "name": "DGND",
         "key": "P8_1"

--- a/src/bone.js
+++ b/src/bone.js
@@ -367,6 +367,26 @@ var pinIndex = [
             "gpio0_26"
         ]
     },
+    // For Blue
+    {
+        "name": "BAT100",
+        "gpio": 26,
+        "led":  "bat100",
+        "mux": "gpmc_ad10",
+        "eeprom": 16,
+        "key": "BAT100",
+        "muxRegOffset": "0x028",
+        "options": [
+            "gpmc_ad10",
+            "lcd_data21",
+            "mmc1_dat2",
+            "mmc2_dat6",
+            "ehrpwm2_tripzone_input",
+            "pr1_mii0_txen",
+            "NA",
+            "gpio0_26"
+        ]
+    },
     {
         "name": "GPIO1_15",
         "gpio": 47,
@@ -409,6 +429,26 @@ var pinIndex = [
         "mux": "gpmc_ad11",
         "eeprom": 17,
         "key": "P8_17",
+        "muxRegOffset": "0x02c",
+        "options": [
+            "gpmc_ad11",
+            "lcd_data20",
+            "mmc1_dat3",
+            "mmc2_dat7",
+            "ehrpwm0_synco",
+            "pr1_mii0_txd3",
+            "NA",
+            "gpio0_27"
+        ]
+    },
+    //  For Blue
+    {
+        "name": "BAT25",
+        "gpio": 27,
+        "led":  "bat25",
+        "mux": "gpmc_ad11",
+        "eeprom": 17,
+        "key": "BAT25",
         "muxRegOffset": "0x02c",
         "options": [
             "gpmc_ad11",
@@ -595,6 +635,46 @@ var pinIndex = [
             "gpio1_29"
         ]
     },
+    //  For Blue
+    {
+        "name": "BAT75",
+        "gpio": 61,
+        "led":  "bat75",
+        "mux": "gpmc_csn0",
+        "eeprom": 37,
+        "key": "BAT75",
+        "muxRegOffset": "0x07c",
+        "options": [
+            "gpmc_csn0",
+            "NA",
+            "NA",
+            "NA",
+            "NA",
+            "NA",
+            "NA",
+            "gpio1_29"
+        ]
+    },
+    //  For Blue, This is a guess
+    {
+        "name": "WIFI",
+        "gpio": 10000,      // Placeholder
+        "led":  "wifi",
+        "mux": "gpmc_csn0",
+        "eeprom": 37,
+        "key": "WIFI",
+        "muxRegOffset": "0x07c",
+        "options": [
+            "gpmc_csn0",
+            "NA",
+            "NA",
+            "NA",
+            "NA",
+            "NA",
+            "NA",
+            "gpio1_29"
+        ]
+    },
     {
         "name": "GPIO2_22",
         "gpio": 86,
@@ -691,6 +771,26 @@ var pinIndex = [
         "mux": "lcd_data15",
         "eeprom": 8,
         "key": "P8_32",
+        "muxRegOffset": "0x0dc",
+        "options": [
+            "lcd_data15",
+            "gpmc_a19",
+            "NA",
+            "mcasp0_ahclkx",
+            "mcasp0_axr3",
+            "NA",
+            "NA",
+            "gpio0_11"
+        ]
+    },
+        // Added for Blue
+    {
+        "name": "BAT50",
+        "gpio": 11,
+        "led": "bat50",
+        "mux": "lcd_data15",
+        "eeprom": 8,
+        "key": "BAT50",
         "muxRegOffset": "0x0dc",
         "options": [
             "lcd_data15",

--- a/src/bone.js
+++ b/src/bone.js
@@ -1324,12 +1324,13 @@ var pinIndex = [
             "gpio1_17"
         ]
     },
-    {       // The next four are hacks to get the Blue GP0 pins 3 and 5 to work
+    {       // The next four are hacks to get the Blue GP0 pins 3 and 5 
+            // and GP1 pins 3 and 4 to work
         "name": "GPIO1_25",
         "gpio": 57,
         "mux": "gpmc_a1",
         "eeprom": 33,
-        "key": "XXX",
+        "key": "GP0_3",
         "key2": "GP0_3",        // Added for Blue
         "muxRegOffset": "0x044",
         "options": [
@@ -1348,7 +1349,7 @@ var pinIndex = [
         "gpio": 116,
         "mux": "gpmc_a1",
         "eeprom": 33,
-        "key": "XXX",
+        "key": "GP0_5",
         "key2": "GP0_5",        // Added for Blue
         "muxRegOffset": "0x044",
         "options": [
@@ -1367,7 +1368,7 @@ var pinIndex = [
         "gpio": 98,
         "mux": "gpmc_a1",
         "eeprom": 33,
-        "key": "XXX",
+        "key": "GP1_3",
         "key2": "GP1_3",        // Added for Blue
         "muxRegOffset": "0x044",
         "options": [
@@ -1386,7 +1387,7 @@ var pinIndex = [
         "gpio": 97,
         "mux": "gpmc_a1",
         "eeprom": 33,
-        "key": "XXX",
+        "key": "GP1_4",
         "key2": "GP1_4",        // Added for Blue
         "muxRegOffset": "0x044",
         "options": [

--- a/src/bone.js
+++ b/src/bone.js
@@ -1324,6 +1324,45 @@ var pinIndex = [
             "gpio1_17"
         ]
     },
+    {       // The next two are hacks to get the Blue GP0 pins 3 and 5 to work
+        "name": "GPIO1_25",
+        "gpio": 57,
+        "mux": "gpmc_a1",
+        "eeprom": 33,
+        "key": "XXX",
+        "key2": "GP0_3",        // Added for Blue
+        "muxRegOffset": "0x044",
+        "options": [
+            "gpmc_a1",
+            "gmii2_rxdv",
+            "rgmii2_rctl",
+            "mmc2_dat0",
+            "gpmc_a17",
+            "pr1_mii1_txd3",
+            "ehrpwm0_synco",
+            "gpio1_25"
+        ]
+    },
+    {
+        "name": "GPIO3_20",
+        "gpio": 116,
+        "mux": "gpmc_a1",
+        "eeprom": 33,
+        "key": "XXX",
+        "key2": "GP0_5",        // Added for Blue
+        "muxRegOffset": "0x044",
+        "options": [
+            "gpmc_a1",
+            "gmii2_rxdv",
+            "rgmii2_rctl",
+            "mmc2_dat0",
+            "gpmc_a17",
+            "pr1_mii1_txd3",
+            "ehrpwm0_synco",
+            "gpio3_20"
+        ]
+    },
+
     {
         "name": "UART1_TXD",
         "gpio": 15,

--- a/src/hw_mainline.js
+++ b/src/hw_mainline.js
@@ -124,7 +124,11 @@ exports.setPinMode = function(pin, pinData, template, resp, callback) {
 exports.setLEDPinToGPIO = function(pin, resp) {
     winston.debug('setLEDPinTGPIO');
     var path;
-    if((pin.led === 'red') || (pin.led === 'green')) {
+    // console.log("setLEDPinToGPIO " + pin);
+    if((pin.led === 'red') || (pin.led === 'green')
+       || (pin.led === 'bat25') || (pin.led === 'bat50')
+       || (pin.led === 'bat75') || (pin.led === 'bat100')
+       || (pin.led === 'wifi')) {
         path = "/sys/class/leds/" + pin.led + "/trigger";
     } else {
         path = "/sys/class/leds/beaglebone:green:" + pin.led + "/trigger";
@@ -162,7 +166,10 @@ exports.writeGPIOValue = function(pin, value, callback) {
         gpioFile[pin.key] = '/sys/class/gpio/gpio' + pin.gpio + '/value';
         if(pin.led) {
             // Handle Blue LEDs
-            if((pin.led === 'red') || (pin.led === 'green')) {
+            if((pin.led === 'red') || (pin.led === 'green')
+                   || (pin.led === 'bat25') || (pin.led === 'bat50')
+                   || (pin.led === 'bat75') || (pin.led === 'bat100')
+                   || (pin.led === 'wifi')) {
                 gpioFile[pin.key] = "/sys/class/leds/";
                 gpioFile[pin.key] += pin.led + "/brightness";
             } else {

--- a/src/hw_mainline.js
+++ b/src/hw_mainline.js
@@ -118,7 +118,13 @@ exports.setPinMode = function(pin, pinData, template, resp, callback) {
 };
 
 exports.setLEDPinToGPIO = function(pin, resp) {
-    var path = "/sys/class/leds/beaglebone:green:" + pin.led + "/trigger";
+    winston.debug('setLEDPinTGPIO');
+    var path;
+    if((pin.led === 'red') || (pin.led === 'green')) {
+        path = "/sys/class/leds/" + pin.led + "/trigger";
+    } else {
+        path = "/sys/class/leds/beaglebone:green:" + pin.led + "/trigger";
+    }
 
     if(my.file_existsSync(path)) {
         fs.writeFileSync(path, "gpio");
@@ -151,8 +157,14 @@ exports.writeGPIOValue = function(pin, value, callback) {
     if(typeof gpioFile[pin.key] == 'undefined') {
         gpioFile[pin.key] = '/sys/class/gpio/gpio' + pin.gpio + '/value';
         if(pin.led) {
-            gpioFile[pin.key] = "/sys/class/leds/beaglebone:";
-            gpioFile[pin.key] += "green:" + pin.led + "/brightness";
+            // Handle Blue LEDs
+            if((pin.led === 'red') || (pin.led === 'green')) {
+                gpioFile[pin.key] = "/sys/class/leds/";
+                gpioFile[pin.key] += pin.led + "/brightness";
+            } else {
+                gpioFile[pin.key] = "/sys/class/leds/beaglebone:";
+                gpioFile[pin.key] += "green:" + pin.led + "/brightness";
+            }
         }
         if(!my.file_existsSync(gpioFile[pin.key])) {
             winston.error("Unable to find gpio: " + gpioFile[pin.key]);

--- a/src/hw_mainline.js
+++ b/src/hw_mainline.js
@@ -81,38 +81,40 @@ exports.setPinMode = function(pin, pinData, template, resp, callback) {
     var p = "ocp:" + pin.key + "_pinmux";
     if(pin.universalName) p = "ocp:" + pin.universalName + "_pinmux";
     var pinmux = my.find_sysfsFile(p, my.is_ocp(), p);
-    if(!pinmux) { throw p + " was not found under " + my.is_ocp(); }
-    if((pinData & 7) == 7) {
-        gpioFile[pin.key] = '/sys/class/gpio/gpio' + pin.gpio + '/value';
-        fs.writeFileSync(pinmux+"/state", 'gpio');
-    } else if(template == 'bspwm') {
-        // at least P9_28 uses pwm2
-        var state = pin.key.indexOf("P9_28") == -1 ? "pwm" : "pwm2";
-        fs.writeFileSync(pinmux+"/state", state);
-        // Buld a path like: /sys/devices/platform/ocp/48304000.epwmss/48304200.ehrpwm/pwm/pwmchip5
-        // pin.pwm.chip looks up the first address and pin.pwm.addr looks up the second
-        // file_find figures which pwmchip to use
-        // pin.pwm.index tells with half of the PWM to use (0 or 1)
-        // prefix is .ecap for P9_28 and P9_42 and .pwm or .ehrpwm for the rest
-        var prefix = pin.pwm.module.indexOf("ecap") == -1 ? ".pwm" : ".ecap";
-        var pwmPath = my.file_find('/sys/devices/platform/ocp/'+pin.pwm.chip
-                + '.epwmss/'+pin.pwm.addr+prefix+'/pwm', 'pwmchip', 1);
-        // Some versions of kernel (4.4.15-bone11 for instance) still use
-        // .ehrpwm for address
-        if (pwmPath == null) {
-        	pwmPath = my.file_find('/sys/devices/platform/ocp/'+pin.pwm.chip
-        		+ '.epwmss/'+pin.pwm.addr+'.ehrpwm/pwm', 'pwmchip', 1)
+    // if(!pinmux) { throw p + " was not found under " + my.is_ocp(); }
+    if(pinmux) {        // This is a hack for the new pins on the Blue that appear not to have a pinmux
+        if((pinData & 7) == 7) {
+            gpioFile[pin.key] = '/sys/class/gpio/gpio' + pin.gpio + '/value';
+            fs.writeFileSync(pinmux+"/state", 'gpio');
+        } else if(template == 'bspwm') {
+            // at least P9_28 uses pwm2
+            var state = pin.key.indexOf("P9_28") == -1 ? "pwm" : "pwm2";
+            fs.writeFileSync(pinmux+"/state", state);
+            // Buld a path like: /sys/devices/platform/ocp/48304000.epwmss/48304200.ehrpwm/pwm/pwmchip5
+            // pin.pwm.chip looks up the first address and pin.pwm.addr looks up the second
+            // file_find figures which pwmchip to use
+            // pin.pwm.index tells with half of the PWM to use (0 or 1)
+            // prefix is .ecap for P9_28 and P9_42 and .pwm or .ehrpwm for the rest
+            var prefix = pin.pwm.module.indexOf("ecap") == -1 ? ".pwm" : ".ecap";
+            var pwmPath = my.file_find('/sys/devices/platform/ocp/'+pin.pwm.chip
+                    + '.epwmss/'+pin.pwm.addr+prefix+'/pwm', 'pwmchip', 1);
+            // Some versions of kernel (4.4.15-bone11 for instance) still use
+            // .ehrpwm for address
+            if (pwmPath == null) {
+            	pwmPath = my.file_find('/sys/devices/platform/ocp/'+pin.pwm.chip
+            		+ '.epwmss/'+pin.pwm.addr+'.ehrpwm/pwm', 'pwmchip', 1)
+            }
+            pwmPrefix[pin.pwm.name] = pwmPath + '/pwm' + pin.pwm.index;
+            if(debug) winston.debug("pwmPrefix[pin.pwm.name] = " + pwmPrefix[pin.pwm.name]);
+            if(debug) winston.debug("pin.pwm.sysfs = " + pin.pwm.sysfs);
+            if(!my.file_existsSync(pwmPrefix[pin.pwm.name])) {
+                fs.appendFileSync(pwmPath+'/export', pin.pwm.index);
+            }
+            fs.appendFileSync(pwmPrefix[pin.pwm.name]+'/enable', 1);
+        } else {
+            resp.err = 'Unknown pin mode template';
         }
-        pwmPrefix[pin.pwm.name] = pwmPath + '/pwm' + pin.pwm.index;
-        if(debug) winston.debug("pwmPrefix[pin.pwm.name] = " + pwmPrefix[pin.pwm.name]);
-        if(debug) winston.debug("pin.pwm.sysfs = " + pin.pwm.sysfs);
-        if(!my.file_existsSync(pwmPrefix[pin.pwm.name])) {
-            fs.appendFileSync(pwmPath+'/export', pin.pwm.index);
-        }
-        fs.appendFileSync(pwmPrefix[pin.pwm.name]+'/enable', 1);
-    } else {
-        resp.err = 'Unknown pin mode template';
-    }
+    }  // if(pinmux)
     if(callback) callback(resp);
     return(resp);
 };

--- a/src/hw_mainline.js
+++ b/src/hw_mainline.js
@@ -82,9 +82,9 @@ exports.setPinMode = function(pin, pinData, template, resp, callback) {
     if(pin.universalName) p = "ocp:" + pin.universalName + "_pinmux";
     var pinmux = my.find_sysfsFile(p, my.is_ocp(), p);
     // if(!pinmux) { throw p + " was not found under " + my.is_ocp(); }
+    gpioFile[pin.key] = '/sys/class/gpio/gpio' + pin.gpio + '/value';
     if(pinmux) {        // This is a hack for the new pins on the Blue that appear not to have a pinmux
         if((pinData & 7) == 7) {
-            gpioFile[pin.key] = '/sys/class/gpio/gpio' + pin.gpio + '/value';
             fs.writeFileSync(pinmux+"/state", 'gpio');
         } else if(template == 'bspwm') {
             // at least P9_28 uses pwm2
@@ -114,7 +114,9 @@ exports.setPinMode = function(pin, pinData, template, resp, callback) {
         } else {
             resp.err = 'Unknown pin mode template';
         }
-    }  // if(pinmux)
+    }  else {
+        winston.info("No pinmux for " + pin.key);
+    }
     if(callback) callback(resp);
     return(resp);
 };


### PR DESCRIPTION
I've added pins:
GP0_3, GP0_4, GP0_5, GP0_6, GP1_3, GP1_4, RED_LED, GREEN_LED, PAUSE and MODE,
all for the BeagleBone Blue.

Some of the pins don't have a pinmux and will print a message saying so and then assume it's mux'ed correctly.

There is still a timing problem when using b.setMode().  If the pin hasn't been exported, bonescript will export it and then set it direction, but writing gpioXX/direction occurs before udev can assign the new permissions.  One work around is to run as root the first time.

--Mark