### PR TITLE
Remove duplicate property muxRegOffset

### DIFF
--- a/src/bone.js
+++ b/src/bone.js
@@ -2083,8 +2083,7 @@ var pinIndex = [
         "ball": {
             "ZCZ": "F15",
             "BSM": "M14"
-        },
-        "muxRegOffset": "0x134"
+        }
     },
     {
         "name": "USB1_VBUS",


### PR DESCRIPTION
The muxRegOffset property was duplicated for gpio 109 in bone.js. This is my first PR through GitHub so I apologize if I've screwed up the workflow.