### PR TITLE
temporary solution for autorun-test

### DIFF
--- a/test/test-autorun2.js
+++ b/test/test-autorun2.js
@@ -1,15 +1,15 @@
 var autorun = require('bonescript').autorun;
 var fs = require('fs');
 var testDir = '/tmp/autorun-test';
-var file0 = testDir + '/autorun-test0.js';
-var file1 = testDir + '/autorun-test1.js';
+var file0 = 'autorun-test0.js';
+var file1 = 'autorun-test1.js';
 
 exports.testAutorun = function (test) {
     var ar = autorun('/tmp/autorun-test');
     var apps = ar.getApps();
     var emitter = ar.getEmitter();
-    //test.expect(2);
-    setTimeout(onTimeout, 3000);
+    test.expect(2);
+    setTimeout(onTimeout, 500);
 
     emitter.on('start', function (file) {
         console.log('Started ' + file);


### PR DESCRIPTION
While i was running the tests off-line i noticed that when running the test for the second time, the output was totally different and was as expected(probably), i think this is due to some problem in creating the files , as ,if i delete the  /temp/autorun-test directory and run the test again , it fails(for the first time). I am not sure whether something i did is wrong, expecting your feedback.