### PR TITLE
patch to handle debugfs not mounted

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "express": "4.13.4",
     "socket.io": "1.4.5",
     "systemd": "0.2.6",
-    "winston": "2.1.1"
+    "winston": "2.1.1",
+    "shelljs": "0.8.2"
   },
   "optionalDependencies": {
     "serialport": "3.1.2",

--- a/src/hw_mainline.js
+++ b/src/hw_mainline.js
@@ -4,6 +4,7 @@ var parse = require('./parse');
 var eeprom = require('./eeprom');
 var util = require('util');
 var winston = require('winston');
+var shell = require('shelljs');
 
 var debug = process.env.DEBUG ? true : false;
 if (debug) {
@@ -47,6 +48,15 @@ var readGPIODirection = function (n, gpio) {
 var readPinMux = function (pin, mode, callback) {
     var pinctrlFile = '/sys/kernel/debug/pinctrl/44e10800.pinmux/pins';
     var muxRegOffset = parseInt(pin.muxRegOffset, 16);
+    //handle the case when debugfs not mounted
+    if (!my.file_existsSync(pinctrlFile)) {
+        //exit code is 1 if /sys/kernel/debug not mounted
+        const umount = shell.exec('mountpoint -q /sys/kernel/debug/').code;
+        if (umount)
+            shell.exec('mount -t debugfs none /sys/kernel/debug/', {
+                silent: true
+            });
+    }
     var readPinctrl = function (err, data) {
         if (err) {
             mode.err = 'readPinctrl error: ' + err;


### PR DESCRIPTION
I have tried to add a patch using shelljs to handle the case when debugfs is not mounted(Issue #61 [still exists]).The issue is solved after adding the patch and I also did note the run-time before and after the change(for this example script: http://beagleboard.org/Support/BoneScript/getPinMode/), the results are :

before making the change :

real	0m8.573s
user	0m7.748s
sys	0m0.564s

after making the change(when debugfs already mounted) :

real	0m8.783s
user	0m8.068s
sys	0m0.516s

after making the change(when debugfs not mounted) :

real	0m10.074s
user	0m9.192s
sys	0m0.680s
