### PR TITLE
Smooth PWM Output

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -236,6 +236,15 @@ f.digitalWrite = function (pin, value, callback) {
     pin = my.getpin(pin);
     if (debug) winston.debug('digitalWrite(' + [pin.key, value] + ');');
     value = parseInt(Number(value), 2) ? 1 : 0;
+    //handle case digitalWrite() on Analog_Out
+    if (pin.pwm != 'undefined') {
+        var gpioEnabled = (7 == f.getPinMode(pin).mux); //check whether pin set as gpio
+        if (!gpioEnabled) {
+            winston.debug([pin.key, value] + ' set as ANALOG_OUTPUT modifying duty cycle according to value');
+            f.analogWrite(pin, value, myCallback); //write duty cycle as per value
+            return (true);
+        }
+    }
 
     hw.writeGPIOValue(pin, value, myCallback);
 
@@ -404,7 +413,7 @@ f.attachInterrupt = function (pin, handler, mode, callback) {
         }
         fs.readSync(gpioInt[n].valuefd, gpioInt[n].value, 0, 1, 0);
         m.pin = pin;
-        m.value = parseInt(Number(gpioInt[n].value), 2);
+        m.value = parseInt(gpioInt[n].value.toString(), 2);
         if (typeof handler == 'function') m.output = handler(m);
         else m.output = {
             handler: handler

--- a/test/test-ffi.js
+++ b/test/test-ffi.js
@@ -2,11 +2,11 @@ var b = require('bonescript');
 var fs = require('fs');
 var testDir = '/tmp/ffi-test';
 var Cfile = testDir + 'ffi-test';
-
+var txtFile = testDir + 'txt-test.txt'
 var args = {
     'main': ['int', ['void']]
 };
-
+var text = "HELLO";
 var cCode = `
 #include <stdio.h>
 int main()
@@ -17,9 +17,20 @@ int main()
 `
 module.exports.testFFI = function (test) {
 
-    test.expect(3);
+    test.expect(5);
     if (!fs.existsSync(testDir)) {
         fs.mkdirSync(testDir);
+    }
+    //test writetxtFile
+    b.writeTextFile(txtFile, text);
+    if (fs.existsSync(txtFile)) {
+        console.log("Write Text File Successful");
+        test.ok(true);
+    }
+    //test readtxtFile
+    if (b.readTextFile(txtFile, text) == text) {
+        console.log("Read Text File Successful");
+        test.ok(true);
     }
     //test mraaGPIO()
     var mraaGPIO = b.mraaGPIO('P9_12');


### PR DESCRIPTION
I have tried to fix these issues related to PWM, 

- spikes occuring while writing zero duty cycle(proposed soln: disabled pwm while writing zero duty/freq)
-  smooth pwm output while sweping pwm frequency(proposed soln:  suggested implementation alongside current implementation)
- digitalWrite() on ANALOG_OUTPUT(proposed soln: write duty cycle according to value(0/1))

https://github.com/beagleboard/bonescript/issues/26
https://github.com/beagleboard/bonescript/issues/30
https://github.com/beagleboard/bonescript/issues/17

I have uploaded the test video here : https://youtu.be/_CiSsroef18

I couldn't figure out how to write test cases for these patches , that was why i included some non relevant tests,please excuse.