### PR TITLE
Fix beagleboard#53 and beagleboard#52

### DIFF
--- a/src/hw_mainline.js
+++ b/src/hw_mainline.js
@@ -346,8 +346,8 @@ var writePWMFreqAndValue = function (pin, pwm, freq, value, resp, callback) {
                 try {
                     if (debug) winston.debug('Stopping PWM');
                     fs.writeFileSync(path + '/enable', "0\n");
-                    callback(null); //if no error
                     tryAgain = false; //do not try again
+                    callback(null); //if no error
                 } catch (ex2) {
                     if (debug) winston.debug('Error stopping PWM: ' + ex2);
                     if (ex2.code == 'EACCES') {

--- a/src/index.js
+++ b/src/index.js
@@ -735,6 +735,52 @@ f.setDate = function (date, callback) {
 };
 f.setDate.args = ['date', 'callback'];
 
+f.insclick = function (click,port, callback) {
+    child_process.exec('sudo insclick ' +click + ' ' +port, insclickResponse);
+
+    function insclickResponse(error, stdout, stderr) {
+        if (typeof callback != 'function') return;
+        else {
+            if (callback.length == 1) {
+                winston.warning("single argument callbacks will be deprecated.please use node-style error-first callbacks: callback(err,response)");
+                callback({
+                    'error': error,
+                    'stdout': stdout,
+                    'stderr': stderr
+                });
+            } else
+                callback({
+                    'error': error,
+                    'stderr': stderr
+                }, stdout);
+        }
+    }
+};
+f.insclick.args = ['click', 'port','callback'];
+
+f.rmclick = function (click, callback) {
+    child_process.exec('sudo rmclick ' + click, rmclickResponse);
+
+    function rmclickResponse(error, stdout, stderr) {
+        if (typeof callback != 'function') return;
+        else {
+            if (callback.length == 1) {
+                winston.warning("single argument callbacks will be deprecated.please use node-style error-first callbacks: callback(err,response)");
+                callback({
+                    'error': error,
+                    'stdout': stdout,
+                    'stderr': stderr
+                });
+            } else
+                callback({
+                    'error': error,
+                    'stderr': stderr
+                }, stdout);
+        }
+    }
+};
+f.rmclick.args = ['click', 'callback'];
+
 f.delay = function (ms) {
     var fiber = fibers.current;
     if (typeof fiber == 'undefined') {

--- a/src/index.js
+++ b/src/index.js
@@ -261,7 +261,7 @@ f.digitalWrite = function (pin, value, callback) {
     if (debug) winston.debug('digitalWrite(' + [pin.key, value] + ');');
     value = parseInt(Number(value), 2) ? 1 : 0;
     //handle case digitalWrite() on Analog_Out
-    if (typeof pin.pwm != 'undefined') {
+    if (typeof pin.pwm != 'undefined' && typeof f.getPinMode(pin).mux != 'undefined') {
         var gpioEnabled = (7 == f.getPinMode(pin).mux); //check whether pin set as gpio
         if (!gpioEnabled) {
             winston.debug([pin.key, value] + ' set as ANALOG_OUTPUT modifying duty cycle according to value');


### PR DESCRIPTION
Fixed https://github.com/beagleboard/bonescript/issues/53 : analogWrite() slow when writing zero duty cycle , this was due to the test condition for async.until() method being misplaced , so the stopPWM() method was invoked continously, fixing the misplaced test condition fixes the issue.

Fixed https://github.com/beagleboard/bonescript/issues/52 : this relates to analogWrite() on digitalOUT being triggered when calling digitalWrite() , this occurs due to mux mode not being fetched, so added an additional check for it.

Both the issues/fixes were tested and found to be fixed on :
```
debian@beaglebone:~/bonescript$ uname -a
Linux beaglebone 4.9.82-ti-r102 #1 SMP PREEMPT Thu Feb 22 01:16:12 UTC 2018 armv7l GNU/Linux
debian@beaglebone:~/bonescript$ cat /etc/dogtag
BeagleBoard.org Debian Image 2018-03-05
```